### PR TITLE
[OpenAI] New Service API versions 2024-05-01-preview and 2024-02-01

### DIFF
--- a/sdk/openai/azure-ai-openai/CHANGELOG.md
+++ b/sdk/openai/azure-ai-openai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for service API version, `2024-04-01-preview`. 
+- Added support for service API versions: `2024-04-01-preview`, `2024-05-01-preview` and `2024-02-01`. 
 - Note that `AOAI` refers to Azure OpenAI and `OAI` refers to OpenAI.
 
 **Audio**

--- a/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIServiceVersion.java
+++ b/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIServiceVersion.java
@@ -43,7 +43,17 @@ public enum OpenAIServiceVersion implements ServiceVersion {
     /**
      * Enum value 2024-04-01-preview.
      */
-    V2024_04_01_PREVIEW("2024-04-01-preview");
+    V2024_04_01_PREVIEW("2024-04-01-preview"),
+
+    /**
+     * Enum value 2024-05-01-preview.
+     */
+    V2024_05_01_PREVIEW("2024-05-01-preview"),
+
+    /**
+     * Enum value 2024-02-01.
+     */
+    V2024_02_01("2024-02-01");
 
     private final String version;
 
@@ -65,6 +75,6 @@ public enum OpenAIServiceVersion implements ServiceVersion {
      * @return The latest {@link OpenAIServiceVersion}.
      */
     public static OpenAIServiceVersion getLatest() {
-        return V2024_04_01_PREVIEW;
+        return V2024_05_01_PREVIEW;
     }
 }


### PR DESCRIPTION
Adding new OpenAI service API versions

# Description

Added support for service API versions, `2024-05-01-preview` and `2024-02-01`
